### PR TITLE
PDF engine selection, documentclass selection, start/stop feature

### DIFF
--- a/plugin/md.vim
+++ b/plugin/md.vim
@@ -10,6 +10,12 @@ else
     endfor
 endif
 
+if exists('g:md_pdf_engine')
+    let s:pdf_engine = g:md_pdf_engine
+else
+    let s:pdf_engine = "pdflatex"
+endif
+
 if (!exists('s:pdf_viewer'))
     echoh1 ErrorMsg
     echo "could not find valid pdf viewer"
@@ -26,9 +32,9 @@ function! s:CompileMd()
     " Only compile when the preview is enabled
     if (s:preview_running == 1)
         if exists('s:async_support')
-            :AsyncRun pandoc "%" -o "%<".pdf && pkill -HUP mupdf
+            execute "AsyncRun pandoc --pdf-engine=" .s:pdf_engine. " % -o %<.pdf && pkill -HUP mupdf"
         else
-            execute "silent !pandoc % -o %:r.pdf &>/dev/null && pkill -HUP mupdf &> /dev/null"
+            execute "silent !pandoc --pdf-engine=" .s:pdf_engine. " % -o %:r.pdf &>/dev/null && pkill -HUP mupdf &> /dev/null"
         endif
     endif
     redraw!

--- a/plugin/md.vim
+++ b/plugin/md.vim
@@ -1,3 +1,5 @@
+let s:preview_running = 0
+
 if exists('g:md_pdf_viewer')
     let s:pdf_viewer = g:md_pdf_viewer
 else 
@@ -21,10 +23,13 @@ endif
 
 
 function! s:CompileMd()
-    if exists('s:async_support')
-        :AsyncRun pandoc "%" -o "%<".pdf && pkill -HUP mupdf
-    else
-        execute "silent !pandoc % -o %:r.pdf &>/dev/null && pkill -HUP mupdf &> /dev/null"
+    " Only compile when the preview is enabled
+    if (s:preview_running == 1)
+        if exists('s:async_support')
+            :AsyncRun pandoc "%" -o "%<".pdf && pkill -HUP mupdf
+        else
+            execute "silent !pandoc % -o %:r.pdf &>/dev/null && pkill -HUP mupdf &> /dev/null"
+        endif
     endif
     redraw!
 endfunction
@@ -35,6 +40,13 @@ function! s:OpenPdf(pdf_viewer)
     redraw!
 endfunction
 
+function! s:StartPreview(pdf_viewer)
+    let s:preview_running = 1
+    call s:OpenPdf(a:pdf_viewer)
+endfunction
+
 
 autocmd BufWritePost *.md call s:CompileMd()
-command! StartMdPreview call s:OpenPdf(s:pdf_viewer)
+command! -nargs=? StartMdPreview call s:StartPreview(s:pdf_viewer)
+command! StopMdPreview let s:preview_running = 0
+

--- a/plugin/md.vim
+++ b/plugin/md.vim
@@ -16,6 +16,12 @@ else
     let s:pdf_engine = "pdflatex"
 endif
 
+if exists('g:md_default_latex_class')
+    let s:latex_class = g:md_default_latex_class
+else
+    let s:latex_class = 'latex'
+endif
+
 if (!exists('s:pdf_viewer'))
     echoh1 ErrorMsg
     echo "could not find valid pdf viewer"
@@ -32,9 +38,9 @@ function! s:CompileMd()
     " Only compile when the preview is enabled
     if (s:preview_running == 1)
         if exists('s:async_support')
-            execute "AsyncRun pandoc --pdf-engine=" .s:pdf_engine. " % -o %<.pdf && pkill -HUP mupdf"
+            execute "AsyncRun pandoc -t " .s:latex_class. " --pdf-engine=" .s:pdf_engine. " % -o %<.pdf && pkill -HUP mupdf"
         else
-            execute "silent !pandoc --pdf-engine=" .s:pdf_engine. " % -o %:r.pdf &>/dev/null && pkill -HUP mupdf &> /dev/null"
+            execute "silent !pandoc -t " .s:latex_class. " --pdf-engine=" .s:pdf_engine. " % -o %:r.pdf &>/dev/null && pkill -HUP mupdf &> /dev/null"
         endif
     endif
     redraw!
@@ -46,13 +52,18 @@ function! s:OpenPdf(pdf_viewer)
     redraw!
 endfunction
 
-function! s:StartPreview(pdf_viewer)
+function! s:StartPreview(pdf_viewer, latex_class)
+    " Latex is always default unless specified in the call or in .vimrc
+    if (a:latex_class != "")
+        let s:latex_class = a:latex_class
+    endif
+
     let s:preview_running = 1
     call s:OpenPdf(a:pdf_viewer)
 endfunction
 
 
 autocmd BufWritePost *.md call s:CompileMd()
-command! -nargs=? StartMdPreview call s:StartPreview(s:pdf_viewer)
+command! -nargs=? StartMdPreview call s:StartPreview(s:pdf_viewer, "<args>")
 command! StopMdPreview let s:preview_running = 0
 

--- a/plugin/md.vim
+++ b/plugin/md.vim
@@ -47,7 +47,9 @@ function! s:CompileMd()
 endfunction
 
 function! s:OpenPdf(pdf_viewer)
-    call s:CompileMd()
+    " A synchronous (locking up) call is necessary here. Otherwise the pdf viewer will open before 
+    " the file has been compiled, hence finding nothing to display.
+    execute "silent !pandoc -t " .s:latex_class. " --pdf-engine=" .s:pdf_engine. " % -o %:r.pdf &>/dev/null && pkill -HUP mupdf &> /dev/null"
     execute "silent !" .a:pdf_viewer. " %:r.pdf &> /dev/null &"
     redraw!
 endfunction


### PR DESCRIPTION
I wrote this mainly for my own needs but thought that this might be useful for others as well. If you don't think this is a good addition for whatever reason, feel free to reject this PR.

* A specific LaTeX PDF engine can be selected by adding `let g:md_pdf_engine` to your .vimrc:
    - Represents the `--pdf-engine=<engine>` switch for pandoc's cli.
    - Default is _pdflatex_ but every engine supported by pandoc will work.
    - Leaving this blank will default to _pdflatex_.
* The LaTeX document class can now be specified by appending it to the `:StartMdPreview` call:
    - Represents the `-t` switch for pandoc's cli.
    - For instance `:StartMdPreview beamer` will compile the pdf as beamer slides instead of the standard A4/Letter format.
    - Leaving this blank will default to _latex_.
* Compilation of the document now only works after explicitly starting the preview with `:StartMdPreview`:
    - The document is compiled once after invoking the command and then automatically when writing changes.
    - Calling `:StartMdPreview` does _not_ use the asynchronous call in order to ensure that the file is generated before the PDF viewer tries to open it.
    - Calling `:StopMdPreview` will disable the automatic compilation again.