### PR TITLE
Fix whitespace preview bug and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,54 @@ To start the preview mode:
 ```
 This will compile your markdown document and open it in one of the above pdf viewers.
 
-After every save the previewer will be refreshed.
+If the preview is currently running every save will recompile the document and the previewer will
+be refreshed.
+
+To stop the preview mode:
+```
+:StopMdPreview
+```
+
+Once the preview is stopped the document won't be automatically compiled when saved.
+
 
 ### Choosing a previewer
 
-Stick the following in your vimrc, replacing <previewer> with the name of your preferred pdf viewer.
+Stick the following in your vimrc, replacing `<previewer>` with the name of your preferred pdf viewer.
 
 ```
 let g:md_pdf_viewer="<previewer>"
+```
+
+### Choosing a pdf engine
+
+Pandoc supports several pdf engines for document compilation. You can choose your preferred engine
+like so:
+
+```
+let g:md_pdf_engine="<engine>"
+```
+
+The default engine is _pdflatex_.
+
+You can read more about pdf engines in the [Pandoc
+manpage](https://manpages.debian.org/testing/pandoc/pandoc.1.en.html)
+
+### Choosing a latex class
+
+Pandoc uses latex to compile pdfs. The default class _latex_ will produce a A4/Letter pdf. You may
+use any of the keywords supported by Pandoc. However, the preview will only work with those
+compiling to pdf, like _beamer_.
+
+Choose your preferred latex class like so:
+
+```
+let g:md_default_latex_class="<class>"
+```
+
+The default class is _latex_.
+
+You can list all available formats by running 
+```
+pandoc --list-output-formats
 ```

--- a/plugin/md.vim
+++ b/plugin/md.vim
@@ -33,6 +33,9 @@ if exists(':AsyncRun') && v:version >= 800
     let s:async_support = 1
 endif
 
+function! s:CompileSynchronous()
+    execute "silent !pandoc -t " .s:latex_class. " --pdf-engine=" .s:pdf_engine shellescape("%") "-o" shellescape("%<.pdf") "&>/dev/null && pkill -HUP mupdf &> /dev/null"
+endfunction
 
 function! s:CompileMd()
     " Only compile when the preview is enabled
@@ -40,7 +43,7 @@ function! s:CompileMd()
         if exists('s:async_support')
             execute "AsyncRun pandoc -t " .s:latex_class. " --pdf-engine=" .s:pdf_engine. " % -o %<.pdf && pkill -HUP mupdf"
         else
-            execute "silent !pandoc -t " .s:latex_class. " --pdf-engine=" .s:pdf_engine. " % -o %:r.pdf &>/dev/null && pkill -HUP mupdf &> /dev/null"
+            call s:CompileSynchronous()
         endif
     endif
     redraw!
@@ -49,8 +52,8 @@ endfunction
 function! s:OpenPdf(pdf_viewer)
     " A synchronous (locking up) call is necessary here. Otherwise the pdf viewer will open before 
     " the file has been compiled, hence finding nothing to display.
-    execute "silent !pandoc -t " .s:latex_class. " --pdf-engine=" .s:pdf_engine. " % -o %:r.pdf &>/dev/null && pkill -HUP mupdf &> /dev/null"
-    execute "silent !" .a:pdf_viewer. " %:r.pdf &> /dev/null &"
+    call s:CompileSynchronous()
+    execute "silent !" .a:pdf_viewer shellescape("%<.pdf") "&> /dev/null &"
     redraw!
 endfunction
 


### PR DESCRIPTION
The _pandoc_ and _pdf viewer_ commands now properly escape any whitespace and special characters. I checked with _zathura_ and _mupdf_. Everything else should work just as well.
I added one more function for clarity and to keep in line with the _one fact in one place_ principle.
I updated the README to include the variables for setting the _pdf-engine_ as well as the _default latex class_.

Good luck with your exams :slightly_smiling_face: 