### PR TITLE
Set relative path when calling pandoc

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -28,11 +28,11 @@ if exists(':AsyncRun') && v:version >= 800
 endif
 
 function! s:CompileSynchronous()
-    execute "silent !pandoc " .s:args. " --resource-path=". expand('%:h') . " " . shellescape("%") "-o" shellescape("%<.pdf") "&>/dev/null && pkill -HUP mupdf &> /dev/null"
+    execute "silent !pandoc " .s:args. " --resource-path=". expand('%:h') . " " . shellescape("%") "-o" shellescape("%<.pdf") " && pkill -HUP mupdf &> /dev/null"
 endfunction
 
 function! s:CompileAsynchronous()
-    execute "AsyncRun pandoc " . s:args. " --resource-path=". expand('%:h') . " % -o %<.pdf && pkill -HUP mupdf"
+    execute "AsyncRun pandoc " . s:args. " --resource-path=". expand('%:h') . " % -o %<.pdf &>".  expand('%:h') ."pandoc-preview.logs && pkill -HUP mupdf"
 endfunction
 
 function! s:CompileMd()

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -28,11 +28,11 @@ if exists(':AsyncRun') && v:version >= 800
 endif
 
 function! s:CompileSynchronous()
-    execute "silent !pandoc " .s:args. " " . shellescape("%") "-o" shellescape("%<.pdf") "&>/dev/null && pkill -HUP mupdf &> /dev/null"
+    execute "silent !pandoc " .s:args. " --resource-path=". expand('%:h') . " " . shellescape("%") "-o" shellescape("%<.pdf") "&>/dev/null && pkill -HUP mupdf &> /dev/null"
 endfunction
 
 function! s:CompileAsynchronous()
-    execute "AsyncRun pandoc " . s:args. " % -o %<.pdf && pkill -HUP mupdf"
+    execute "AsyncRun pandoc " . s:args. " --resource-path=". expand('%:h') . " % -o %<.pdf && pkill -HUP mupdf"
 endfunction
 
 function! s:CompileMd()

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -28,11 +28,11 @@ if exists(':AsyncRun') && v:version >= 800
 endif
 
 function! s:CompileSynchronous()
-    execute "silent !pandoc " .s:args. " --resource-path=". expand('%:h') . " " . shellescape("%") "-o" shellescape("%<.pdf") " && pkill -HUP mupdf &> /dev/null"
+    execute "silent !pandoc " .s:args. " --resource-path=". shellescape('%:h') . " " . shellescape("%") "-o" shellescape("%<.pdf") " &>".  shellesacpe('%:h') ."/.pandoc-preview.logs && pkill -HUP mupdf &> /dev/null"
 endfunction
 
 function! s:CompileAsynchronous()
-    execute "AsyncRun pandoc " . s:args. " --resource-path=". expand('%:h') . " % -o %<.pdf &>".  expand('%:h') ."pandoc-preview.logs && pkill -HUP mupdf"
+    execute "AsyncRun pandoc " . s:args. " --resource-path=". shellescape('%:h') . " % -o %<.pdf &>".  shellesacpe('%:h') ."/.pandoc-preview.logs && pkill -HUP mupdf"
 endfunction
 
 function! s:CompileMd()

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -28,11 +28,11 @@ if exists(':AsyncRun') && v:version >= 800
 endif
 
 function! s:CompileSynchronous()
-    execute "silent !pandoc " .s:args. " --resource-path=". shellescape('%:h') . " " . shellescape("%") "-o" shellescape("%<.pdf") " &>".  shellesacpe('%:h') ."/.pandoc-preview.logs && pkill -HUP mupdf &> /dev/null"
+    execute "silent !pandoc " .s:args. " --resource-path=". shellescape('%:h') . " " . shellescape("%") "-o" shellescape("%<.pdf") " &>".  shellescape('%:h') ."/.pandoc-preview.logs && pkill -HUP mupdf &> /dev/null"
 endfunction
 
 function! s:CompileAsynchronous()
-    execute "AsyncRun pandoc " . s:args. " --resource-path=". shellescape('%:h') . " % -o %<.pdf &>".  shellesacpe('%:h') ."/.pandoc-preview.logs && pkill -HUP mupdf"
+    execute "AsyncRun pandoc " . s:args. " --resource-path=". shellescape('%:h') . " % -o %<.pdf &>".  shellescape('%:h') ."/.pandoc-preview.logs && pkill -HUP mupdf"
 endfunction
 
 function! s:CompileMd()


### PR DESCRIPTION
set '--relative-path' to the file's current directory when running pandoc so relative image linking works if vim is ran from another directory.